### PR TITLE
Update poster's shareable description when there's data for a given year

### DIFF
--- a/api/posters/start/start.spec.ts
+++ b/api/posters/start/start.spec.ts
@@ -107,6 +107,7 @@ test('should generate user activity', async () => {
     dominantLanguage: repos[0].language,
     dominantRepository: repos[0].name,
     totalLinesOfCode: 4965,
+    totalRepositories: 5,
     weeks: [
       {
         week: 14,
@@ -184,6 +185,7 @@ test('should be able to generate based on selected year', async () => {
     dominantLanguage: undefined,
     dominantRepository: undefined,
     totalLinesOfCode: 0,
+    totalRepositories: 0,
     weeks: [],
   })
 })

--- a/api/posters/start/start.spec.ts
+++ b/api/posters/start/start.spec.ts
@@ -185,7 +185,7 @@ test('should be able to generate based on selected year', async () => {
     dominantLanguage: undefined,
     dominantRepository: undefined,
     totalLinesOfCode: 0,
-    totalRepositories: 0,
+    totalRepositories: 5,
     weeks: [],
   })
 })

--- a/api/posters/start/start.ts
+++ b/api/posters/start/start.ts
@@ -20,7 +20,7 @@ import {
   getWeeksWithDominantLanguageAndRepository,
   sendPosterMail,
   sendUpdateToClient,
-  getRepositoryStatistics,
+  getDominantRepository,
   getDominantLanguage,
   getGitHubToken,
 } from './start.utils'
@@ -66,9 +66,8 @@ export function startImplementation(event: SQSEvent) {
         repositories = repositories.concat(arr)
       }
 
-      logger.info(
-        `Repositories are done! Analyzing ${repositories.length} repos`,
-      )
+      const totalRepositories = repositories.length
+      logger.info(`Repositories are done! Analyzing ${totalRepositories} repos`)
 
       const repositoriesStats = await getRepositoryStats(
         repositories,
@@ -104,9 +103,7 @@ export function startImplementation(event: SQSEvent) {
         repositoryLanguages,
       )
 
-      const {dominantRepository, totalRepositories} = getRepositoryStatistics(
-        repositoryOverallTotal,
-      )
+      const dominantRepository = getDominantRepository(repositoryOverallTotal)
       const dominantLanguage = getDominantLanguage(languageCount)
 
       const name = githubName ? githubName.trim() : username

--- a/api/posters/start/start.ts
+++ b/api/posters/start/start.ts
@@ -20,7 +20,7 @@ import {
   getWeeksWithDominantLanguageAndRepository,
   sendPosterMail,
   sendUpdateToClient,
-  getDominantRepository,
+  getRepositoryStatistics,
   getDominantLanguage,
   getGitHubToken,
 } from './start.utils'
@@ -104,7 +104,9 @@ export function startImplementation(event: SQSEvent) {
         repositoryLanguages,
       )
 
-      const dominantRepository = getDominantRepository(repositoryOverallTotal)
+      const {dominantRepository, totalRepositories} = getRepositoryStatistics(
+        repositoryOverallTotal,
+      )
       const dominantLanguage = getDominantLanguage(languageCount)
 
       const name = githubName ? githubName.trim() : username
@@ -114,6 +116,7 @@ export function startImplementation(event: SQSEvent) {
         year,
         totalLinesOfCode,
         weeks: completeWeeks.filter(val => val !== undefined) as PosterWeek[],
+        totalRepositories,
         dominantRepository,
         dominantLanguage,
       }

--- a/api/posters/start/start.utils.tsx
+++ b/api/posters/start/start.utils.tsx
@@ -349,7 +349,7 @@ export function getWeeksWithDominantLanguageAndRepository(
   })
 }
 
-export function getRepositoryStatistics(
+export function getDominantRepository(
   repositoryOverallTotal: Record<string, number>,
 ) {
   const repositoriesNames = Object.keys(repositoryOverallTotal)
@@ -357,7 +357,7 @@ export function getRepositoryStatistics(
   const dominantRepository =
     repositoriesNames[indexOfMax(repositoriesActivities)]
 
-  return {dominantRepository, totalRepositories: repositoriesNames.length}
+  return dominantRepository
 }
 
 export function getDominantLanguage(languageCount: Record<string, number>) {

--- a/api/posters/start/start.utils.tsx
+++ b/api/posters/start/start.utils.tsx
@@ -349,7 +349,7 @@ export function getWeeksWithDominantLanguageAndRepository(
   })
 }
 
-export function getDominantRepository(
+export function getRepositoryStatistics(
   repositoryOverallTotal: Record<string, number>,
 ) {
   const repositoriesNames = Object.keys(repositoryOverallTotal)
@@ -357,7 +357,7 @@ export function getDominantRepository(
   const dominantRepository =
     repositoriesNames[indexOfMax(repositoriesActivities)]
 
-  return dominantRepository
+  return {dominantRepository, totalRepositories: repositoriesNames.length}
 }
 
 export function getDominantLanguage(languageCount: Record<string, number>) {

--- a/libs/types/poster.ts
+++ b/libs/types/poster.ts
@@ -15,6 +15,7 @@ export interface Poster {
   year: number
   followers: number
   dominantLanguage: string
+  totalRepositories?: number
   dominantRepository: string
   totalLinesOfCode: number
   weeks: PosterWeek[]

--- a/src/pages/posters/[slug].tsx
+++ b/src/pages/posters/[slug].tsx
@@ -128,7 +128,7 @@ export default function PosterBySlug({
   )
 }
 
-export const getPosterDescription = ({
+const getPosterDescription = ({
   year,
   totalRepositories,
   dominantLanguage,

--- a/src/pages/posters/[slug].tsx
+++ b/src/pages/posters/[slug].tsx
@@ -75,13 +75,15 @@ export default function PosterBySlug({
     )
   }
 
+  const description = getPosterDescription(posterData)
+
   return (
     <>
       <NextSeo
         title={`${posterData.name}'s ${posterData.year} Year in Code`}
         openGraph={{
           type: 'website',
-          description: `Come take a look at the art generated from ${posterData.name}’s code in ${posterData.year}!`,
+          description,
           images: [
             {
               url: `${constants.site.cloudfront_url}/${posterImages.openGraph}`,
@@ -124,6 +126,22 @@ export default function PosterBySlug({
       />
     </>
   )
+}
+
+export const getPosterDescription = ({
+  year,
+  totalRepositories,
+  dominantLanguage,
+}: Poster) => {
+  const dominantLanguageDescription = `mostly ${dominantLanguage}`
+
+  const reposSuffix = totalRepositories === 1 ? '' : 's'
+
+  const posterDescription = totalRepositories
+    ? `on ${totalRepositories} repo${reposSuffix} and ${dominantLanguageDescription}`
+    : dominantLanguageDescription
+
+  return `Take a look at my ${year} year in code where I worked ${posterDescription}. What’s your year in code look like?`
 }
 
 export async function getServerSideProps({


### PR DESCRIPTION
- Store in the database the total number of repositories the user worked in a given year.
- Update the poster's social media description to include the *# repos* and *dominant language*